### PR TITLE
Consider entity selection when applying poultice

### DIFF
--- a/wildcraft/src/Item/ItemWCPoultice.cs
+++ b/wildcraft/src/Item/ItemWCPoultice.cs
@@ -75,7 +75,7 @@ namespace wildcraft
                 if (!isPoulticeActive) {
                     var buff = new PoulticeBuff();
                     buff.init(health);
-                    buff.Apply(byEntity);
+                    buff.Apply(entitySel?.Entity != null ? entitySel.Entity : byEntity);
                     if(isPoisonOak && this.Code.GetName().Contains("yarrow")){
                         BuffStuff.BuffManager.GetActiveBuff(byEntity, "PoisonOak").Remove();
                     }


### PR DESCRIPTION
Hello,
@RogueRaidenTV contacted me asking for his pets being healable by your mods poultices.
I did not know how to properly handle this on my end so I figured I would give it a shot and implement it here.
I hope the changes are sufficient.

Maybe this is a bit dangerous as one can now accidentally heal drifters i suppose.