### PR TITLE
Remove conflicting variables

### DIFF
--- a/wildcraft/src/BlockEntity/BETallBerryBush.cs
+++ b/wildcraft/src/BlockEntity/BETallBerryBush.cs
@@ -25,9 +25,6 @@ namespace wildcraft
 
         RoomRegistry roomreg;
         new public int roomness;
-        
-        new public bool Pruned;
-        new public double LastPrunedTotalDays;
 
         public BETallBerryBush() : base()
         {

--- a/wildcraft/src/BlockEntity/BEWildcraftBerryBush.cs
+++ b/wildcraft/src/BlockEntity/BEWildcraftBerryBush.cs
@@ -17,10 +17,6 @@ namespace wildcraft
 {
     public class BEWildcraftBerryBush : BlockEntityBerryBush
     {
-
-        public bool Pruned;
-        public double LastPrunedTotalDays;
-
         public BEWildcraftBerryBush() : base()
         {
 


### PR DESCRIPTION
Pruned and LastPrunedTotalDays are defined on VintageStory.GameContent.BlockEntityBerryBush. Removing these from BETallBerryBush and BEWildcraftBerryBush appears to fix the issue with saving and loading, but there is still a separate issue affecting harvesting a pruned bush. This appears to cause the new variant of the bush to spawn with Pruned set to false instead of true.